### PR TITLE
Add script to deploy and generate invite without running server

### DIFF
--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -132,7 +132,6 @@
     "ship": "yarn surge",
     "theme": "npx gulp less",
     "watch": "node ./scripts/watch.js",
-    "preinstall": "npx npm-force-resolutions",
     "prettier": "npx prettier --write . '!(node_module|build)/**/*'"
   }
 }

--- a/packages/server/deploy-and-generate-invite.ts
+++ b/packages/server/deploy-and-generate-invite.ts
@@ -1,0 +1,17 @@
+import { ethers } from "ethers";
+
+import { setupContract, setupSigner, signDelegation } from './utils';
+
+// Workaround for importing JSON files
+const { rpcUrl } = require('./secrets.json');
+
+const DEFAULT_CONTRACT_NAME = 'MobyMask'
+
+let provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+let signer: ethers.Wallet;
+
+setupSigner(provider)
+  .then(_signer => signer = _signer)
+  .then(() => setupContract(signer))
+  .then(({ name = DEFAULT_CONTRACT_NAME, registry }) => signDelegation(provider, signer, registry, name))
+  .catch(console.error);

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -1,40 +1,23 @@
-import { Router } from "@open-rpc/server-js";
 import { ethers } from "ethers";
-import assert from "assert";
-const types = require('../react-app/src/types')
+import { Router } from "@open-rpc/server-js";
+
+import { setupSigner, setupContract, signDelegation, Invocation } from './utils'
+
 const cors = require('cors');
 const createGanacheProvider = require('./providers/ganacheProvder');
-const createTypedMessage = require('../react-app/src/createTypedMessage');
-const sigUtil = require('eth-sig-util');
-const { generateUtil } = require('eth-delegatable-utils');
-const {
-  TypedDataUtils,
-} = sigUtil;
-const {
-  typedSignatureHash,
-  encodeData,
-} = TypedDataUtils;
-
-const BASE_URI = 'https://mobymask.com/#';
 
 // For reads, clients can hit the node directly.
 /* so for now, we just care about this server being able to relay transactions.
   * We can add more features later, like pre-simulating txs so only process good ones.
   */
 
-const fs = require('fs');
-const path = require('path');
-const configPath = path.join(__dirname, './config.json');
-const { privateKey, mnemonic, rpcUrl, baseURI = BASE_URI } = require('./secrets.json');
+const { mnemonic, rpcUrl } = require('./secrets.json');
 
 const openrpcDocument = require('./openrpc.json');
 const { parseOpenRPCDocument } = require("@open-rpc/schema-utils-js");
 const { Server } = require("@open-rpc/server-js");
 const openrpcServer = require("@open-rpc/server-js");
-const { HTTPTransport, HTTPSTransport } = openrpcServer.transports;
-
-const phisherRegistryArtifacts = require('../hardhat/artifacts/contracts/PhisherRegistry.sol/PhisherRegistry.json');
-const { abi } = phisherRegistryArtifacts;
+const { HTTPTransport } = openrpcServer.transports;
 
 let provider: ethers.providers.Provider;
 if (process.env.ENV === 'PROD') {
@@ -48,7 +31,6 @@ if (process.env.ENV === 'PROD') {
 
 let registry: ethers.Contract;
 let signer: ethers.Wallet;
-let _chainId: string;
 let _name: string = 'MobyMask';
 
 const methodMapping = {
@@ -60,25 +42,19 @@ const methodMapping = {
       return false;
     }
     return true;
-  }, 
+  },
 };
 
-setupSigner()
-  .then(setupContract)
-  .then(_registry => registry = _registry)
+setupSigner(provider)
+  .then(_signer => signer = _signer)
+  .then(() => setupContract(signer))
+  .then(params => {
+    _name = params.name ?? _name;
+    registry = params.registry;
+  })
   .then(activateServer)
-  .then(signDelegation)
+  .then(() => signDelegation(provider, signer, registry, _name))
   .catch(console.error);
-
-async function setupSigner () {
-  if (mnemonic) {
-    signer = ethers.Wallet.fromMnemonic(mnemonic).connect(provider);
-  }
-
-  if (privateKey) {
-    signer = new ethers.Wallet(privateKey, provider)
-  }
-}
 
 async function activateServer () {
   const router = new Router(openrpcDocument, methodMapping);
@@ -125,112 +101,9 @@ async function activateServer () {
   // server.addTransports([ httpTransport /*, httpsTransport */] ); // will be started immediately.
 }
 
-
-
-async function setupContract (): Promise<ethers.Contract> {
-  try {
-    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-    const { address, chainId, name } = config;
-    _name = name;
-    _chainId = chainId;
-    return attachToContract(address)
-  } catch (err) {
-    console.log('No config detected, deploying contract and creating one.');
-    return deployContract()
-  }
-}
-
-async function deployContract () {
-  const Registry = new ethers.ContractFactory(abi, phisherRegistryArtifacts.bytecode, signer);
-  const balance = await provider.getBalance(signer?.address && signer.address);
-  const _name = 'MobyMask';
-  const registry = await Registry.deploy(_name);
-
-  const address = registry.address;
-  fs.writeFileSync(configPath, JSON.stringify({ address, name: _name, chainId: registry.deployTransaction.chainId }, null, 2));
-  try {
-    return await registry.deployed();
-  } catch (err) {
-    console.log('Deployment failed, trying to attach to existing contract.', err);
-    throw err;
-  }
-}
-
-async function attachToContract(address: string) {
-  const Registry = new ethers.Contract(address, abi, signer);
-  const registry = await Registry.attach(address);
-  console.log('Attaching to existing contract');
-  const deployed = await registry.deployed();
-  return deployed;
-}
-
-type Invocation = {
-  transaction: Transaction,
-  authority: SignedDelegation[],
-};
-
-type Transaction = {
-  to: string,
-  gasLimit: string,
-  data: string,
-};
-
-type SignedDelegation = {
-  delegation: Delegation,
-  signature: string,
-}
-
-type Delegation = {
-  delegate: string,
-  authority: string,
-  caveats: Caveat[],
-};
-
-type Caveat = {
-  enforcer: string,
-  terms: string,
-}
-
 type SignedInvocation = {
   invocation: Invocation,
   signature: string,
-}
-
-async function signDelegation () {
-
-  const { chainId } = await provider.getNetwork();
-  const utilOpts = {
-    chainId,
-    verifyingContract: registry.address,
-    name: _name,      
-  };
-  console.log('util opts', utilOpts);
-  const util = generateUtil(utilOpts)
-  const delegate = ethers.Wallet.createRandom();
-
-  // Prepare the delegation message.
-  // This contract is also a revocation enforcer, so it can be used for caveats:
-  const delegation = {
-    delegate: delegate.address,
-    authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
-    caveats: [{
-      enforcer: registry.address,
-      terms: '0x0000000000000000000000000000000000000000000000000000000000000000',
-    }],
-  };
-
-  const typedMessage = createTypedMessage(registry, delegation, 'Delegation', _name, _chainId);
-
-  // Owner signs the delegation:
-  const signedDelegation = util.signDelegation(delegation, signer.privateKey);
-  const invitation = {
-    v:1,
-    signedDelegations: [signedDelegation],
-    key: delegate.privateKey,
-  }
-  console.log('A SIGNED DELEGATION/INVITE LINK:');
-  console.log(JSON.stringify(invitation, null, 2));
-  console.log(baseURI + '/members?invitation=' + encodeURIComponent(JSON.stringify(invitation)));
 }
 
 function fromHexString (hexString: string) {
@@ -248,4 +121,3 @@ function fromHexString (hexString: string) {
   }
   return new Uint8Array(mapped);
 }
-

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "ts-node index.ts",
+    "deployAndGenerateInvite": "ts-node deploy-and-generate-invite.ts",
     "rootGen": "npx ts-node rootInviteGen.ts",
     "generateClient": "open-rpc-generator generate -c open-rpc-generator-config.json"
   },

--- a/packages/server/utils/index.ts
+++ b/packages/server/utils/index.ts
@@ -5,14 +5,11 @@ import path from 'path';
 // Workaround for missing types
 const { generateUtil } = require('eth-delegatable-utils');
 
-const BASE_URI = 'https://mobymask.com/#';
+const DEFAULT_BASE_URI = 'https://mobymask.com/#';
 
 // Workaround for importing JSON files
 const phisherRegistryArtifacts = require('../../hardhat/artifacts/contracts/PhisherRegistry.sol/PhisherRegistry.json');
-const { privateKey, mnemonic, baseURI = BASE_URI } = require('../secrets.json');
-
-
-const DEFAULT_BASE_URI = 'https://mobymask.com/#';
+const { privateKey, mnemonic, baseURI = DEFAULT_BASE_URI } = require('../secrets.json');
 
 const configPath = path.join(__dirname, '../config.json');
 const { abi } = phisherRegistryArtifacts;
@@ -127,5 +124,5 @@ export async function signDelegation (provider: ethers.providers.Provider, signe
   }
   console.log('A SIGNED DELEGATION/INVITE LINK:');
   console.log(JSON.stringify(invitation, null, 2));
-  console.log((baseURI ?? DEFAULT_BASE_URI) + '/members?invitation=' + encodeURIComponent(JSON.stringify(invitation)));
+  console.log(baseURI + '/members?invitation=' + encodeURIComponent(JSON.stringify(invitation)));
 }

--- a/packages/server/utils/index.ts
+++ b/packages/server/utils/index.ts
@@ -1,0 +1,131 @@
+import { ethers } from "ethers";
+import fs from 'fs';
+import path from 'path';
+
+// Workaround for missing types
+const { generateUtil } = require('eth-delegatable-utils');
+
+const BASE_URI = 'https://mobymask.com/#';
+
+// Workaround for importing JSON files
+const phisherRegistryArtifacts = require('../../hardhat/artifacts/contracts/PhisherRegistry.sol/PhisherRegistry.json');
+const { privateKey, mnemonic, baseURI = BASE_URI } = require('../secrets.json');
+
+
+const DEFAULT_BASE_URI = 'https://mobymask.com/#';
+
+const configPath = path.join(__dirname, '../config.json');
+const { abi } = phisherRegistryArtifacts;
+
+export async function setupSigner (provider: ethers.providers.Provider) {
+  if (mnemonic) {
+    return ethers.Wallet.fromMnemonic(mnemonic).connect(provider);
+  }
+
+  return new ethers.Wallet(privateKey, provider)
+}
+
+type SetupContract = {
+  name?: string;
+  chainId?: string;
+  registry: ethers.Contract;
+}
+
+export async function setupContract (signer: ethers.Wallet): Promise<SetupContract> {
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    const { address, chainId, name } = config;
+    const registry = await attachToContract(address, signer)
+
+    return { name, chainId, registry }
+  } catch (err) {
+    console.log('No config detected, deploying contract and creating one.');
+    const registry = await deployContract(signer);
+
+    return { registry }
+  }
+}
+
+async function deployContract (signer: ethers.Wallet) {
+  const Registry = new ethers.ContractFactory(abi, phisherRegistryArtifacts.bytecode, signer);
+  const _name = 'MobyMask';
+  const registry = await Registry.deploy(_name);
+
+  const address = registry.address;
+  fs.writeFileSync(configPath, JSON.stringify({ address, name: _name, chainId: registry.deployTransaction.chainId }, null, 2));
+  try {
+    return await registry.deployed();
+  } catch (err) {
+    console.log('Deployment failed, trying to attach to existing contract.', err);
+    throw err;
+  }
+}
+
+async function attachToContract(address: string, signer: ethers.Wallet) {
+  const Registry = new ethers.Contract(address, abi, signer);
+  const registry = await Registry.attach(address);
+  console.log('Attaching to existing contract');
+  const deployed = await registry.deployed();
+  return deployed;
+}
+
+export type Invocation = {
+  transaction: Transaction,
+  authority: SignedDelegation[],
+};
+
+type Transaction = {
+  to: string,
+  gasLimit: string,
+  data: string,
+};
+
+type SignedDelegation = {
+  delegation: Delegation,
+  signature: string,
+}
+
+type Delegation = {
+  delegate: string,
+  authority: string,
+  caveats: Caveat[],
+};
+
+type Caveat = {
+  enforcer: string,
+  terms: string,
+}
+
+export async function signDelegation (provider: ethers.providers.Provider, signer: ethers.Wallet, registry: ethers.Contract, name: string) {
+  const { chainId } = await provider.getNetwork();
+  const utilOpts = {
+    chainId,
+    verifyingContract: registry.address,
+    name,
+  };
+  console.log('util opts', utilOpts);
+  const util = generateUtil(utilOpts)
+  const delegate = ethers.Wallet.createRandom();
+
+  // Prepare the delegation message.
+  // This contract is also a revocation enforcer, so it can be used for caveats:
+  const delegation = {
+    delegate: delegate.address,
+    authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    caveats: [{
+      enforcer: registry.address,
+      terms: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    }],
+  };
+
+  // Owner signs the delegation:
+  const signedDelegation = util.signDelegation(delegation, signer.privateKey);
+  const invitation = {
+    v:1,
+    signedDelegations: [signedDelegation],
+    key: delegate.privateKey,
+  }
+  console.log('A SIGNED DELEGATION/INVITE LINK:');
+  console.log(JSON.stringify(invitation, null, 2));
+  console.log((baseURI ?? DEFAULT_BASE_URI) + '/members?invitation=' + encodeURIComponent(JSON.stringify(invitation)));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7701,7 +7701,7 @@ babel-loader@8.1.0:
     pify "^4.0.1"
     schema-utils "^2.6.5"
 
-babel-loader@^8.1.0, babel-loader@^8.2.3:
+babel-loader@^8.2.3:
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.5.tgz#d45f585e654d5a5d90f5350a779d7647c5ed512e"
   integrity sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==


### PR DESCRIPTION
Part of https://github.com/cerc-io/stack-orchestrator/issues/264

- Added a `deployAndGenerateInvite` script
- Removed `preinstall` script from react-app package.json
  - Throws error while installing dependencies as [package-lock.json file had been deleted](https://github.com/delegatable/MobyMask/commit/5b0c7fa5a0d0966a8772b7a318d89bea1985de99)
  